### PR TITLE
Travis CI set up. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - "3.7"
+
+
+matrix:
+  include:
+  - os: linux
+    sudo: required
+    services:
+      - docker
+
+before_install:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker pull abhibp1993/iglsynth:dev
+  - docker run -v $(pwd):/home/iglsynth/ abhibp1993/iglsynth:dev /bin/sh -c "cd /home/iglsynth/ && ls"
+  - docker ps -a
+  
+
+script:
+  - docker run -v $(pwd):/home/iglsynth/ abhibp1993/iglsynth:dev /bin/sh -c "cd /home/iglsynth/ && python3 -m pytest"


### PR DESCRIPTION
Travis CI is set up to run pytest on every commit. 

* Uses `abhibp1993/iglsynth:dev` docker file. 
