### PR TITLE
Evaluation for Propositional Logic Formulas

### DIFF
--- a/iglsynth/logic/core.py
+++ b/iglsynth/logic/core.py
@@ -1,7 +1,7 @@
-import spot
 from abc import ABC
 from typing import Callable
 from iglsynth.util.graph import *
+import iglsynth.util.spot as spot
 
 
 ########################################################################################################################

--- a/iglsynth/util/spot.py
+++ b/iglsynth/util/spot.py
@@ -1,0 +1,64 @@
+from spot import *
+
+
+def substitute(self, formula, new_formula, *args):
+    """
+    Substitution is only validated for propositional logic formulas.
+    It has been implemented for LTL, but is not tested.
+    """
+    k = self.kind()
+
+    if k in (op_ff, op_tt):
+        return self
+
+    elif k in (op_eword, op_ap):
+        if self == formula:
+            return new_formula
+
+        return self
+
+    elif k in (op_Not, op_X, op_F, op_G, op_Closure,
+             op_NegClosure, op_NegClosureMarked):
+
+        if self == formula:
+            return new_formula
+
+        f = substitute(self[0], formula, new_formula, *args)
+        return formula.unop(k, f)
+
+    elif k in (op_Xor, op_Implies, op_Equiv, op_U, op_R, op_W,
+             op_M, op_EConcat, op_EConcatMarked, op_UConcat):
+
+        if self[0] == formula:
+            f1 = new_formula
+        else:
+            f1 = substitute(self[0], formula, new_formula, *args)
+
+        if self[1] == formula:
+            f2 = new_formula
+        else:
+            f2 = substitute(self[1], formula, new_formula, *args)
+
+        return formula.binop(k, f1, f2)
+
+    elif k in (op_Or, op_OrRat, op_And, op_AndRat, op_AndNLM,
+             op_Concat, op_Fusion):
+
+        f = []
+        for x in self:
+            if x == formula:
+                tmp = new_formula
+            else:
+                tmp = substitute(x, formula, new_formula, *args)
+
+            f.append(tmp)
+
+        return formula.multop(k, f)
+
+    elif k in (op_Star, op_FStar):
+        ValueError("IGLSynth does not support op_Star and op_FStar operators for substitution.")
+
+    raise ValueError("unknown type of formula")
+
+
+formula.substitute = substitute

--- a/iglsynth/util/tests/test_spot.py
+++ b/iglsynth/util/tests/test_spot.py
@@ -1,0 +1,113 @@
+import pytest
+spot = pytest.importorskip("iglsynth.util.spot")
+
+
+def test_import_spot():
+    try:
+        import spot
+        version = spot.version()
+        version = version.split(".")
+        major = int(version[0])
+        minor = int(version[1])
+
+        assert major >= 2
+        assert minor >= 8
+
+        return True
+
+    except:
+        raise AssertionError("Spot is not imported successfully!!!")
+
+
+def test_spot_substitute_tt_ff():
+    """ Test AP subsitution only. """
+
+    # Define true and false formula
+    tt = spot.formula("true")
+    ff = spot.formula("false")
+
+    # Try substituting true with true/false (nothing should happen)
+    new_f = tt.substitute(formula=tt, new_formula=tt)
+    assert new_f == tt
+
+    new_f = tt.substitute(formula=tt, new_formula=ff)
+    assert new_f == tt
+
+    new_f = tt.substitute(formula=ff, new_formula=tt)
+    assert new_f == tt
+
+    new_f = tt.substitute(formula=ff, new_formula=ff)
+    assert new_f == tt
+
+    # Try substituting true with true/false (nothing should happen)
+    new_f = ff.substitute(formula=tt, new_formula=tt)
+    assert new_f == ff
+
+    new_f = ff.substitute(formula=tt, new_formula=ff)
+    assert new_f == ff
+
+    new_f = ff.substitute(formula=ff, new_formula=tt)
+    assert new_f == ff
+
+    new_f = ff.substitute(formula=ff, new_formula=ff)
+    assert new_f == ff
+
+
+def test_spot_substitute_ap():
+    """ Test AP subsitution only. """
+
+    a = spot.formula("a")
+    b = spot.formula("b")
+    tt = spot.formula("true")
+    ff = spot.formula("false")
+
+    # Substitute a
+    new_f = a.substitute(formula=a, new_formula=tt)
+    assert new_f == tt
+
+    new_f = a.substitute(formula=a, new_formula=ff)
+    assert new_f == ff
+
+    new_f = a.substitute(formula=a, new_formula=a)
+    assert new_f == a
+
+    new_f = a.substitute(formula=a, new_formula=b)
+    assert new_f == b
+
+
+def test_spot_substitute_pl():
+    """ Test AP subsitution only. """
+
+    a = spot.formula("a")
+    b = spot.formula("b")
+    tt = spot.formula("true")
+    ff = spot.formula("false")
+
+    phi0 = spot.formula("!a")
+    phi1 = spot.formula("a & b")
+
+    # Substitute phi0
+    new_f = phi0.substitute(formula=a, new_formula=tt)
+    assert new_f == ff
+
+    new_f = phi0.substitute(formula=a, new_formula=ff)
+    assert new_f == tt
+
+    new_f = phi0.substitute(formula=a, new_formula=b)
+    assert new_f == spot.formula("!b")
+
+    # Substitute phi1
+    new_f = phi1.substitute(formula=a, new_formula=tt)
+    assert new_f == spot.formula("b")
+
+    new_f = new_f.substitute(formula=b, new_formula=tt)
+    assert new_f == tt
+
+    new_f = phi1.substitute(formula=a, new_formula=ff)
+    assert new_f == ff
+
+    # Substitute a with b
+    new_f = phi1.substitute(formula=a, new_formula=b)
+    assert new_f == spot.formula("b")
+
+


### PR DESCRIPTION
Features:

* iglsynth.util.spot extends spot.formula with "substitute" function.
* The substitute function replaces AP's in spot.formula with other AP's or true/false. 
* PL.substitute function is implemented to use above substitute function for implementing PL.evaluate functionality.

* pytests are passing. 
